### PR TITLE
Fix is path ignored

### DIFF
--- a/crates/ignore/src/is_ignored.rs
+++ b/crates/ignore/src/is_ignored.rs
@@ -8,34 +8,21 @@ use std::path::Path;
 /// in any parent directories of the given path.
 ///
 /// NOTE: This API ignores any errors encountered while parsing the ignore files.
-// pub fn is_path_ignored(path: &Path) -> bool {
-//     let ig_root = IgnoreBuilder::new().build();
-//     let mut cur_ig = ig_root.clone();
-//     let ancestors = path.ancestors().skip(1).take(5).collect::<Vec<&Path>>();
-//     for ancestor in ancestors.iter().rev() {
-//         let ig = ig_root.add_parents(ancestor).0;
-//
-//         if cur_ig.matched(ancestor, ancestor.is_dir()).is_ignore() {
-//             return true;
-//         }
-//         let (igtmp, _e) = ig.add_child(ancestor);
-//
-//         cur_ig = igtmp;
-//     }
-//     cur_ig.matched(path, path.is_dir()).is_ignore()
-// }
-
 pub fn is_path_ignored(path: &Path) -> bool {
-    let (ignore, _e) = IgnoreBuilder::new().build().add_parents(path);
-    let mut cur_ig = ignore.clone();
-    for ancestor in path.ancestors() {
+    let ig_root = IgnoreBuilder::new().build();
+    let mut cur_ig = ig_root.clone();
+    let ancestors = path.ancestors().skip(1).collect::<Vec<&Path>>();
+    for ancestor in ancestors.iter().rev() {
+        let ig = ig_root.add_parents(ancestor).0;
+
         if cur_ig.matched(ancestor, ancestor.is_dir()).is_ignore() {
             return true;
         }
-        let (ig, _e) = cur_ig.add_child(ancestor);
-        cur_ig = ig;
+        let (igtmp, _e) = ig.add_child(ancestor);
+
+        cur_ig = igtmp;
     }
-    false
+    cur_ig.matched(path, path.is_dir()).is_ignore()
 }
 
 #[cfg(test)]

--- a/crates/ignore/src/is_ignored.rs
+++ b/crates/ignore/src/is_ignored.rs
@@ -8,6 +8,23 @@ use std::path::Path;
 /// in any parent directories of the given path.
 ///
 /// NOTE: This API ignores any errors encountered while parsing the ignore files.
+// pub fn is_path_ignored(path: &Path) -> bool {
+//     let ig_root = IgnoreBuilder::new().build();
+//     let mut cur_ig = ig_root.clone();
+//     let ancestors = path.ancestors().skip(1).take(5).collect::<Vec<&Path>>();
+//     for ancestor in ancestors.iter().rev() {
+//         let ig = ig_root.add_parents(ancestor).0;
+//
+//         if cur_ig.matched(ancestor, ancestor.is_dir()).is_ignore() {
+//             return true;
+//         }
+//         let (igtmp, _e) = ig.add_child(ancestor);
+//
+//         cur_ig = igtmp;
+//     }
+//     cur_ig.matched(path, path.is_dir()).is_ignore()
+// }
+
 pub fn is_path_ignored(path: &Path) -> bool {
     let (ignore, _e) = IgnoreBuilder::new().build().add_parents(path);
     let mut cur_ig = ignore.clone();
@@ -67,7 +84,7 @@ mod tests {
         mkdirp(td.path().join("zibi"));
         mkdirp(td.path().join(".git"));
 
-        wfile(td.path().join(".ignore"), "bar");
+        wfile(td.path().join(".gitignore"), "bar");
         wfile(td.path().join("bar/a.txt"), "");
         wfile(td.path().join("zibi/a.txt"), "");
 


### PR DESCRIPTION
I still haven't found a test that fails the old code and passes the new one other than real paths from an existing repo (which is not realistic for a test)

This new code is mimicking the implementation of the `Walk` object better:
1. iterate over the paths in their natural order order
2. the logic of when to add parents and when to add children is closer to how it's done in the `Iterator::next` implementation of `Walk`.