### PR TITLE
add a test that fails before the fix

### DIFF
--- a/crates/ignore/src/is_ignored.rs
+++ b/crates/ignore/src/is_ignored.rs
@@ -108,4 +108,21 @@ mod tests {
         assert!(is_path_ignored(&td.path().join("foo/bar/baz/zibi.txt")));
         assert!(!is_path_ignored(&td.path().join("foo/b_foo.txt")));
     }
+
+    #[test]
+    fn multiple_ignores_should_affect_only_paths_below_them() {
+        let td = TempDir::new().unwrap();
+        mkdirp(td.path().join("foo/.git"));
+        mkdirp(td.path().join("foo/bar/baz"));
+
+        wfile(td.path().join("foo/.gitignore"), "/bar.txt");
+
+        wfile(td.path().join("foo/bar.txt"), "");
+        wfile(td.path().join("foo/bar/baz/bar.txt"), "");
+        wfile(td.path().join("foo/bar/baz/zibi.txt"), "");
+
+        assert!(is_path_ignored(&td.path().join("foo/bar.txt")));
+        assert!(!is_path_ignored(&td.path().join("foo/bar/baz/bar.txt")));
+        assert!(!is_path_ignored(&td.path().join("foo/bar/baz/zibi.txt")));
+    }
 }

--- a/crates/ignore/src/is_ignored.rs
+++ b/crates/ignore/src/is_ignored.rs
@@ -110,7 +110,7 @@ mod tests {
     }
 
     #[test]
-    fn multiple_ignores_should_affect_only_paths_below_them() {
+    fn should_resolve_ignore_rules_correctly() {
         let td = TempDir::new().unwrap();
         mkdirp(td.path().join("foo/.git"));
         mkdirp(td.path().join("foo/bar/baz"));


### PR DESCRIPTION
i don't fully understand why exactly this case failed the old code and passes the new one, but it does:
![image](https://github.com/tabnine/tabnine-ripgrep/assets/67855609/a00fbc17-ead7-483e-80cf-d77615630160)


I assume that since in the old code, I did the path iteration the other way around and I added the parent and children ignores incorrectly, it led to the relative path resolution being wrong.
Anyway, it's good that I found such a case 🤷🏻‍♂️ 